### PR TITLE
[PHP8.1対応] bool型をarrayに変換

### DIFF
--- a/src/Import/CsvImport.php
+++ b/src/Import/CsvImport.php
@@ -27,6 +27,7 @@ class CsvImport extends AppImport
                 mb_convert_variables($arrayEncoding, $importEncoding, $data);
                 $csvData[] = $data;
             }
+            $data = array();
 
             $i = 0;
             foreach ($csvData as $line) {


### PR DESCRIPTION
PHP8.1で `Deprecated Error` になる部分の修正