### PR TITLE
ダブルコーテーションが正しく閉じられてない場合の処理を追加しました

### DIFF
--- a/src/Import/CsvImport.php
+++ b/src/Import/CsvImport.php
@@ -90,7 +90,7 @@ class CsvImport extends AppImport
         $e = preg_quote($e);
         $_line = "";
         $eof = false; // Added for PHP Warning.
-        while ( $eof != true ) {
+        while (($eof != true) && (!feof($handle))) {
             $_line .= (empty($length) ? fgets($handle) : fgets($handle, $length));
             $itemcnt = preg_match_all('/'.$e.'/', $_line, $dummy);
             if ($itemcnt % 2 == 0) $eof = true;

--- a/tests/TestCase/Import/CsvImportTest.php
+++ b/tests/TestCase/Import/CsvImportTest.php
@@ -80,6 +80,52 @@ class CsvImportTest extends TestCase
     }
 
     /**
+     * Test EOF
+     *
+     * @return void
+     */
+    public function test_loadCsvEof()
+    {
+        $test1_csv_path = dirname(dirname(dirname(__FILE__))) . '/test_app/test_eof.csv';
+        $column = [
+            'column1',
+            'column2',
+            'column3',
+        ];
+        $csvData = $this->CsvImport->import($test1_csv_path, $column);
+        //テストファイル
+        //1行目
+        $result1 = [
+            'column1' => '1',
+            'column2' => '2',
+            'column3' => '3'
+        ];
+        $this->assertTrue(
+            $csvData[0] === $result1
+        );
+
+        //2行目
+        $result2 = [
+            'column1' => 'あ',
+            'column2' => 'い',
+            'column3' => 'う'
+        ];
+        $this->assertTrue(
+            $csvData[1] === $result2
+        );
+
+        //3行目
+        $result3 = [
+            'column1' => 'ho"ge',
+            'column2' => "fuga",
+            'column3' => "hoge1\nhoge2"
+        ];
+        $this->assertTrue(
+            $csvData[2] === $result3
+        );
+    }
+
+    /**
      * Test initialize method
      *
      * @return void

--- a/tests/test_app/test_eof.csv
+++ b/tests/test_app/test_eof.csv
@@ -1,0 +1,4 @@
+1,2,3
+‚ ,‚¢,‚¤
+ho"ge,fuga,hoge1
+hoge2


### PR DESCRIPTION
以下のようなダブルコーテーションが正しく閉じられていない場合に `CsvImport::fgetcsv_reg` で無限ループしていたので
ファイル終端をチェックする条件を追加しました。

```
aaa,bbb,ccc
ddd,eee,"fff
```