### PR TITLE
strlenとstr_padのdeprecated対応

### DIFF
--- a/src/Export/FixedLengthExport.php
+++ b/src/Export/FixedLengthExport.php
@@ -112,17 +112,24 @@ class FixedLengthExport extends AppExport {
     {
         // 存在チェック
         if (!array_key_exists($fixedOptionKey, $listVal)) {
-            //必要なデータが存在しないエラー
             throw new Exception('data not exist');
-        } else if (strlen($listVal[$fixedOptionKey]) > $fixedInfo['length']) {
+        }
+
+        $value = $listVal[$fixedOptionKey];
+
+        if (is_null($value)) {
+            $value = '';
+        }
+
+        if (strlen($value) > $fixedInfo['length']) {
             throw new Exception('length error');
         }
 
         // typeごとの値のセット
-        if ($fixedInfo['type'] == 'text') {
-            $returnText = str_pad($listVal[$fixedOptionKey], $fixedInfo['length']);
-        } elseif ($fixedInfo['type'] == 'integer') {
-            $returnText = sprintf('%0' . $fixedInfo['length'] . 's', ($listVal[$fixedOptionKey]));
+        if ($fixedInfo['type'] === 'text') {
+            $returnText = str_pad($value, $fixedInfo['length']);
+        } elseif ($fixedInfo['type'] === 'integer') {
+            $returnText = sprintf('%0' . $fixedInfo['length'] . 's', $value);
         } else {
             throw new Exception('type error');
         }


### PR DESCRIPTION
PHP 8.1 以降で `null` を `strlen()` や `str_pad()` に渡すと `Deprecated` 警告が出るため、該当箇所を修正しました。

## 変更内容

- `valueSet()` メソッド内で `$listVal[$fixedOptionKey]` が `null` の可能性を考慮し、空文字列に変換する処理を追加
- `strlen()` と `str_pad()` に渡す値が必ず `string` 型になるようにキャスト処理を追加

## 修正前のエラー例

```text
PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated
PHP Deprecated:  str_pad(): Passing null to parameter #1 ($string) of type string is deprecated
